### PR TITLE
fix: reajuste consulta get_all_identificacion

### DIFF
--- a/controllers/formulacion.go
+++ b/controllers/formulacion.go
@@ -537,12 +537,14 @@ func (c *FormulacionController) GetAllIdentificacion() {
 				dato_str := identificacion["dato"].(string)
 				json.Unmarshal([]byte(dato_str), &dato)
 
-				var identi map[string]interface{}
-				dato_aux1 := dato["rhf"].(string)
-				if dato_aux1 == "{}" {
+				var identi map[string]interface{} = nil
+				dato_aux := ""
+
+				dato_aux = dato["rhf"].(string)
+				if dato_aux == "{}" {
 					result["rhf"] = "{}"
 				} else {
-					json.Unmarshal([]byte(dato_aux1), &identi)
+					json.Unmarshal([]byte(dato_aux), &identi)
 					for key := range identi {
 						element := identi[key].(map[string]interface{})
 						if element["activo"] == true {
@@ -552,13 +554,14 @@ func (c *FormulacionController) GetAllIdentificacion() {
 					result["rhf"] = data_identi
 				}
 
+				identi = nil
 				data_identi = nil
 
-				dato_aux2 := dato["rhv_pre"].(string)
-				if dato_aux2 == "{}" {
+				dato_aux = dato["rhv_pre"].(string)
+				if dato_aux == "{}" {
 					result["rhv_pre"] = "{}"
 				} else {
-					json.Unmarshal([]byte(dato_aux2), &identi)
+					json.Unmarshal([]byte(dato_aux), &identi)
 					for key := range identi {
 						element := identi[key].(map[string]interface{})
 						if element["activo"] == true {
@@ -567,13 +570,15 @@ func (c *FormulacionController) GetAllIdentificacion() {
 					}
 					result["rhv_pre"] = data_identi
 				}
+
+				identi = nil
 				data_identi = nil
 
-				dato_aux3 := dato["rhv_pos"].(string)
-				if dato_aux3 == "{}" {
+				dato_aux = dato["rhv_pos"].(string)
+				if dato_aux == "{}" {
 					result["rhv_pos"] = "{}"
 				} else {
-					json.Unmarshal([]byte(dato_aux3), &identi)
+					json.Unmarshal([]byte(dato_aux), &identi)
 					for key := range identi {
 						element := identi[key].(map[string]interface{})
 						if element["activo"] == true {
@@ -582,13 +587,15 @@ func (c *FormulacionController) GetAllIdentificacion() {
 					}
 					result["rhv_pos"] = data_identi
 				}
+
+				identi = nil
 				data_identi = nil
 
-				dato_aux4 := dato["rubros"].(string)
-				if dato_aux4 == "{}" {
+				dato_aux = dato["rubros"].(string)
+				if dato_aux == "{}" {
 					result["rubros"] = "{}"
 				} else {
-					json.Unmarshal([]byte(dato_aux4), &identi)
+					json.Unmarshal([]byte(dato_aux), &identi)
 					for key := range identi {
 						element := identi[key].(map[string]interface{})
 						if element["activo"] == true {
@@ -597,6 +604,8 @@ func (c *FormulacionController) GetAllIdentificacion() {
 					}
 					result["rubros"] = data_identi
 				}
+
+				identi = nil
 				data_identi = nil
 
 				c.Data["json"] = map[string]interface{}{"Success": true, "Status": "200", "Message": "Successful", "Data": result}


### PR DESCRIPTION
- Se eliminan variables "dato_aux1, dato_aux2, ... " no eran necesarias.
- Se vacía variable "identi" luego de cada ejecución del Unmarshal, esta estaba acumulando los datos anteriores.