### PR TITLE
Hotfix: Creación de endpoints para avalar plan y consultar trimestres

### DIFF
--- a/controllers/seguimiento.go
+++ b/controllers/seguimiento.go
@@ -523,6 +523,42 @@ func (c *SeguimientoController) CrearReportes() {
 	c.ServeJSON()
 }
 
+// ObtenerTrimestres ...
+// @Title ObtenerTrimestres
+// @Description get Seguimiento
+// @Param	vigencia 	path 	string	true		"The key for staticblock"
+// @Success 200
+// @Failure 404
+// @router /trimestres/:vigencia [get]
+func (c *SeguimientoController) ObtenerTrimestres() {
+	defer func() {
+		if err := recover(); err != nil {
+			localError := err.(map[string]interface{})
+			c.Data["message"] = (beego.AppConfig.String("appname") + "/" + "SeguimientoController" + "/" + (localError["funcion"]).(string))
+			c.Data["data"] = (localError["err"])
+			if status, ok := localError["status"]; ok {
+				c.Abort(status.(string))
+			} else {
+				c.Abort("404")
+			}
+		}
+	}()
+
+	vigencia := c.Ctx.Input.Param(":vigencia")
+	if len(vigencia) == 0 {
+		c.Data["json"] = map[string]interface{}{"Success": false, "Status": "404", "Message": "Request containt incorrect params", "Data": nil}
+	}
+
+	trimestres, err := seguimientohelper.ObtenerTrimestres(vigencia)
+	if err != nil {
+		panic(map[string]interface{}{"funcion": "AvalarPlan", "err": "Trimestres no encontrados", "status": "404"})
+	}
+
+	c.Data["json"] = map[string]interface{}{"Success": true, "Status": "200", "Message": "Successful", "Data": trimestres}
+
+	c.ServeJSON()
+}
+
 // GetPeriodos ...
 // @Title GetPeriodos
 // @Description get Seguimiento

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "github.com/udistrital/planeacion_mid/routers"
 	apistatus "github.com/udistrital/utils_oas/apiStatusLib"
+	"github.com/udistrital/utils_oas/xray"
 
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/plugins/cors"
@@ -27,6 +28,7 @@ func main() {
 		ExposeHeaders:    []string{"Content-Length"},
 		AllowCredentials: true,
 	}))
+	xray.InitXRay()
 	beego.ErrorController(&customerrorv2.CustomErrorController{})
 	apistatus.Init()
 	beego.Run()

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -718,4 +718,13 @@ func init() {
             Filters: nil,
             Params: nil})
 
+    beego.GlobalControllerRouter["github.com/udistrital/planeacion_mid/controllers:SeguimientoController"] = append(beego.GlobalControllerRouter["github.com/udistrital/planeacion_mid/controllers:SeguimientoController"],
+        beego.ControllerComments{
+            Method: "ObtenerTrimestres",
+            Router: "/trimestres/:vigencia",
+            AllowHTTPMethods: []string{"get"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
 }

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -549,6 +549,15 @@ func init() {
 
     beego.GlobalControllerRouter["github.com/udistrital/planeacion_mid/controllers:SeguimientoController"] = append(beego.GlobalControllerRouter["github.com/udistrital/planeacion_mid/controllers:SeguimientoController"],
         beego.ControllerComments{
+            Method: "AvalarPlan",
+            Router: "/avalar/:idPlan",
+            AllowHTTPMethods: []string{"post"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
+    beego.GlobalControllerRouter["github.com/udistrital/planeacion_mid/controllers:SeguimientoController"] = append(beego.GlobalControllerRouter["github.com/udistrital/planeacion_mid/controllers:SeguimientoController"],
+        beego.ControllerComments{
             Method: "CrearReportes",
             Router: "/crear_reportes/:plan/:tipo",
             AllowHTTPMethods: []string{"post"},

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2665,6 +2665,32 @@
                     }
                 }
             }
+        },
+        "/seguimiento/trimestres/{vigencia}": {
+            "get": {
+                "tags": [
+                    "seguimiento"
+                ],
+                "description": "get Seguimiento",
+                "operationId": "SeguimientoController.ObtenerTrimestres",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "vigencia",
+                        "description": "The key for staticblock",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "404": {
+                        "description": ""
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1981,6 +1981,32 @@
                 }
             }
         },
+        "/seguimiento/avalar/{idPlan}": {
+            "post": {
+                "tags": [
+                    "seguimiento"
+                ],
+                "description": "Post para avalar plan y crear reportes de seguimiento",
+                "operationId": "SeguimientoController.AvalarPlan",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "idPlan",
+                        "description": "The key for staticblock",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "400": {
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/seguimiento/crear_reportes/{plan}/{tipo}": {
             "post": {
                 "tags": [

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -1306,6 +1306,23 @@ paths:
           description: ""
           schema:
             $ref: '#/definitions/models.Reportes'
+  /seguimiento/avalar/{idPlan}:
+    post:
+      tags:
+      - seguimiento
+      description: Post para avalar plan y crear reportes de seguimiento
+      operationId: SeguimientoController.AvalarPlan
+      parameters:
+      - in: path
+        name: idPlan
+        description: The key for staticblock
+        required: true
+        type: string
+      responses:
+        "200":
+          description: ""
+        "400":
+          description: ""
   /seguimiento/crear_reportes/{plan}/{tipo}:
     post:
       tags:

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -1760,6 +1760,23 @@ paths:
             $ref: '#/definitions/models.Seguimiento'
         "403":
           description: :id is empty
+  /seguimiento/trimestres/{vigencia}:
+    get:
+      tags:
+      - seguimiento
+      description: get Seguimiento
+      operationId: SeguimientoController.ObtenerTrimestres
+      parameters:
+      - in: path
+        name: vigencia
+        description: The key for staticblock
+        required: true
+        type: string
+      responses:
+        "200":
+          description: ""
+        "404":
+          description: ""
 definitions:
   '{}':
     title: '{}'


### PR DESCRIPTION
- Se creó un endpoint para cambiar el estado de un plan a avalado y crear los reportes de seguimiento (Anteriormente habían 2 endpoints para hacer las acciones).
- Se creó un endpoint para traer los trimestres asociados a un id de vigencia específico que se utilizó en el módulo de administrar sistema.