### PR TITLE
fix: Se controla error cuando en subgrupo-detalle -> dato_plan alguna…

### DIFF
--- a/helpers/seguimientoHelper/seguimiento.helper.go
+++ b/helpers/seguimientoHelper/seguimiento.helper.go
@@ -415,7 +415,7 @@ func GetCuantitativoPlan(seguimiento map[string]interface{}, index string, trime
 										dato_plan_str := subgrupo_detalle[0]["dato_plan"].(string)
 										json.Unmarshal([]byte(dato_plan_str), &dato_plan)
 										nombreDetalle := strings.ToLower(subgrupo_detalle[0]["nombre"].(string))
-										if dato_plan[index] == nil || dato_plan[index].(map[string]interface{})["dato"] == "" {
+										if dato_plan[index] == nil || dato_plan[index].(map[string]interface{})["dato"] == nil || dato_plan[index].(map[string]interface{})["dato"] == "" {
 											break
 										}
 


### PR DESCRIPTION
Se controla error cuando en el campo `dato_plan.dato` de la colección subgrupo-detalle se almacena `null` como en el ejemplo:

```json
{
	"_id": "65eb4b7949b14837a6e8dfcd",
	"activo": true,
	"armonizacion_dato": null,
	"dato": "{\"type\":\"numeric\",\"required\":\"false\"}",
	"dato_plan": {
		"1": {
			"activo": true,
			"dato": 100,
			"index": "1",
			"observacion": "Sin observación"
		},
		"2": {
			"activo": true,
			"dato": null,
			"index": "2",
			"observacion": "Sin observación"
		},
		"3": {
			"activo": true,
			"dato": 1,
			"index": "3",
			"observacion": "Sin observación"
		},
		"4": {
			"activo": true,
			"dato": "",
			"index": "4",
			"observacion": "Sin observación"
		}
	},
	"descripcion": "Meta",
	"nombre": "subgrupo detalle Meta",
	"subgrupo_id": "65eb4b7949b14878ffe8dfc6",
	"fecha_creacion": "2024-03-08T17:31:37.676Z",
	"fecha_modificacion": "2024-05-07T04:39:18.572Z",
	"__v": 0
}
```