### PR TITLE
feat: se quitó el break de for para que elimine todas las coincidencias de unidades encontradas

### DIFF
--- a/helpers/formulacionHelper/formulacion.helper.go
+++ b/helpers/formulacionHelper/formulacion.helper.go
@@ -2394,7 +2394,6 @@ func eliminarUnidad(unidades []map[string]interface{}, id int) []map[string]inte
 		if unidad["Id"].(int) == id {
 			// Eliminar la unidad del slice
 			unidades = append(unidades[:i], unidades[i+1:]...)
-			break
 		}
 	}
 	return unidades


### PR DESCRIPTION
- Se quitó el break de for para que de elimine todas las coincidencias de unidades encontradas al realizar la parametrización de fechas de formulación/seguimiento